### PR TITLE
Correcting spelling in quickdive.md

### DIFF
--- a/chapters/quickdive.md
+++ b/chapters/quickdive.md
@@ -125,7 +125,7 @@ kubectl expose deployment result --type=NodePort --port 80
   * Access results ui application. When you submit vote, do the results change ?
 
 
-#### Cleaing up
+#### Cleaning up
 
 Once you are done observing, you could delete it with the following commands,
 


### PR DESCRIPTION
In quickdive.md, header `Cleaing up` corrected to `Cleaning up`.